### PR TITLE
Remove definition of unused function 'round'

### DIFF
--- a/src/permutohedral.cpp
+++ b/src/permutohedral.cpp
@@ -28,11 +28,11 @@
 #include "permutohedral.h"
 #include <iostream>
 
-#ifdef WIN32
-inline int round(double X) {
-    return int(X+.5);
-}
-#endif
+// #ifdef WIN32
+// inline int round(double X) {
+//     return int(X+.5);
+// }
+// #endif
 
 #ifdef __SSE__
 // SSE Permutoheral lattice


### PR DESCRIPTION
Not only is it ununsed, it brings up an error of redifinition of 'double round(double)' in cmath/math.h. (reporting this on VS 2013. Build failed because of this error.) Consider removing it altogether?
